### PR TITLE
Fixed equip menu opening over pause menu

### DIFF
--- a/Turn-Based-RPG/objects/obj_equip_screen/Step_0.gml
+++ b/Turn-Based-RPG/objects/obj_equip_screen/Step_0.gml
@@ -5,12 +5,6 @@ left_key = keyboard_check_pressed(ord("A"));
 right_key = keyboard_check_pressed(ord("D"));
 accept_key = keyboard_check_pressed(ord("E"));
 
-// Open the equip screen on pressing "O"
-if (keyboard_check_pressed(ord("O")) && room != rm_world_map && room != rm_access_menu) {
-	show_equip = !show_equip;
-	obj_player._disabled = !obj_player._disabled;
-}
-
 // Get selected character
 selected_character += left_key - right_key;
 if (selected_character >= ds_list_size(global.party)) {

--- a/Turn-Based-RPG/objects/obj_equip_screen/obj_equip_screen.yy
+++ b/Turn-Based-RPG/objects/obj_equip_screen/obj_equip_screen.yy
@@ -14,7 +14,7 @@
     "path": "folders/Objects/UI.yy",
   },
   "parentObjectId": null,
-  "persistent": true,
+  "persistent": false,
   "physicsAngularDamping": 0.1,
   "physicsDensity": 0.5,
   "physicsFriction": 0.2,

--- a/Turn-Based-RPG/objects/obj_stats_screen/obj_stats_screen.yy
+++ b/Turn-Based-RPG/objects/obj_stats_screen/obj_stats_screen.yy
@@ -14,7 +14,7 @@
     "path": "folders/Objects/Stats.yy",
   },
   "parentObjectId": null,
-  "persistent": true,
+  "persistent": false,
   "physicsAngularDamping": 0.1,
   "physicsDensity": 0.5,
   "physicsFriction": 0.2,


### PR DESCRIPTION
Equip menu can no longer be opened using 'O' and can no longer affect opening multiple pause menus or player movement.
Resolves #288 