### PR TITLE
Fixed crash when selecting empty inventory space

### DIFF
--- a/Turn-Based-RPG/objects/obj_inventory/Step_0.gml
+++ b/Turn-Based-RPG/objects/obj_inventory/Step_0.gml
@@ -30,7 +30,7 @@ if (_show_inventory && _show_tooltip == false) {
 	}
 }
 
-if (_show_tooltip == false && _accept_key && _pressed == false) {
+if (_show_tooltip == false && _accept_key && _pressed == false && global.inventory[# _x_pos, _y_pos] != noone) {
 	 show_debug_message("Testing 1");
 	_show_tooltip = true;
 	if (global.inventory[# _x_pos, _y_pos]._item_type == item_type.weapon || 


### PR DESCRIPTION
Fixed bug where game would crash upon selecting an empty inventory space.
Resolves #271 